### PR TITLE
Added support for dmaker.fan.p5 model

### DIFF
--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -58,7 +58,6 @@ class FanXiaomi extends HTMLElement {
                         direction: "right"
                     });
                 }
-                return false;
             }
             // 定义事件
             ui.querySelector('.c1').onclick = () => {
@@ -99,7 +98,7 @@ class FanXiaomi extends HTMLElement {
                 }
             }
             ui.querySelector('.var-natural').onclick = () => {
-                //this.log('Natural')
+                this.log('Natural')
                 if (ui.querySelector('.fanbox').classList.contains('active')) {
                     let u = ui.querySelector('.var-natural')
                     if (u.classList.contains('active') === false) {
@@ -351,7 +350,6 @@ Natural
             }
         } else {
             activeElement.classList.remove('active')
-            // div.querySelector('.bg-on').removeChild(div.querySelector('.contaifner'))
         }
 
         // State
@@ -362,7 +360,6 @@ Natural
             }
         } else {
             activeElement.classList.remove('active')
-            // div.querySelector('.bg-on').removeChild(div.querySelector('.container'))
         }
 
         // Speed Level
@@ -374,7 +371,6 @@ Natural
             }
         } else {
             activeElement.classList.remove('active')
-            // iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-0-box-outline"></iron-icon>'
         }
         let direct_speed_int = Number(direct_speed)
         if (direct_speed_int <= 20) {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -175,11 +175,6 @@ class FanXiaomi extends HTMLElement {
                         newTimer = 60
                     }
                     
-                    // p5 uses minutes, others use seconds
-                    if (model !== 'dmaker.fan.p5'){
-                        newTime = newTime * 60
-                    }
-                    
                     hass.callService('fan', 'xiaomi_miio_set_delay_off', {
                         delay_off_countdown: newTimer
                     });

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -22,11 +22,10 @@ class FanXiaomi extends HTMLElement {
         }
 
         const attrs = state.attributes;
-        const model = attrs['model']
-        
-        const p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
-        const za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
-        
+
+        let p5_speed_list = [1, 35, 70, 100]
+        let za4_speed_list = [20, 40, 60, 80, 100]
+        let model = attrs['model']
         let speed_list
         if (model === 'dmaker.fan.p5') {
             speed_list = p5_speed_list
@@ -87,24 +86,24 @@ class FanXiaomi extends HTMLElement {
                     let icon = u.querySelector('.icon-waper > iron-icon')
                     let newSpeed
                     if (icon.getAttribute('icon') == "mdi:numeric-1-box-outline") {
-                        newSpeed = speed_list['Level 2']
+                        newSpeed = speed_list[1]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
-                        newSpeed = speed_list['Level 3']
+                        newSpeed = speed_list[2]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-3-box-outline") {
-                        newSpeed = speed_list['Level 4']
+                        newSpeed = speed_list[3]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        if (model === 'dmaker.fan.p5') { // For p5 last speed is Level 4
-                            newSpeed = speed_list['Level 1']
+                        if (speed_list[5] === undefined) {
+                            newSpeed = speed_list[0]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                         } else {
-                            newSpeed = speed_list['Level 5']
+                            newSpeed = speed_list[4]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
                         }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {
-                        newSpeed = speed_list['Level 1']
+                        newSpeed = speed_list[0]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                     } else {
                         this.log('Error setting fan speed')
@@ -484,8 +483,8 @@ Natural
         }
         let direct_speed_int = Number(direct_speed)
         
-        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
-            direct_speed_int = speed_list[speed]
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed            
+            direct_speed_int = speed_list[parseInt(speed[speed.length-1])-1] //speed contains "Level 1" value
             if (mode === 'nature') {
                 natural_speed = true
             } else if (mode === 'normal') {
@@ -493,13 +492,13 @@ Natural
             }
         }
         
-        if (direct_speed_int <= speed_list['Level 1']) {
+        if (direct_speed_int <= speed_list[0]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 2']) {
+        } else if (direct_speed_int <= speed_list[1]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 3']) {
+        } else if (direct_speed_int <= speed_list[2]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 4']) {
+        } else if (direct_speed_int <= speed_list[3]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
         } else {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -6,29 +6,21 @@ class FanXiaomi extends HTMLElement {
         const state = hass.states[entityId];
         const ui = this.getUI();
 
-        if(state === undefined){
-            if (!this.card) {
-                const card = document.createElement('ha-card');
-                card.className = 'fan-xiaomi';
-                card.appendChild(ui);
+        if (!this.card){
+            const card = document.createElement('ha-card');
+            card.className = 'fan-xiaomi'
+            card.appendChild(ui)
+
+            // Check if fan is disconnected
+            if(state === undefined){
                 card.classList.add('offline');
                 this.card = card;
                 this.appendChild(card);
                 ui.querySelector('.var-title').textContent = this.config.name+' (Disconnected)';
                 return;
             }
-        }
 
-        const attrs = state.attributes;
-
-        if (!this.card) {
-            const card = document.createElement('ha-card');
-            card.className = 'fan-xiaomi'
-
-            // 创建UI
-            card.appendChild(ui)
-
-            //调整风扇角度事件绑定
+            // Angle adjustment event bindings
             ui.querySelector('.left').onmouseover = () => {
                 ui.querySelector('.left').classList.replace('hidden','show')
             }
@@ -59,7 +51,7 @@ class FanXiaomi extends HTMLElement {
                     });
                 }
             }
-            // 定义事件
+            
             ui.querySelector('.c1').onclick = () => {
                 this.log('Toggle')
                 hass.callService('fan', 'toggle', {
@@ -140,7 +132,10 @@ class FanXiaomi extends HTMLElement {
             this.card = card;
             this.appendChild(card);
         }
-        //设置值更新UI
+
+        const attrs = state.attributes;
+
+        // Set and update UI parameters
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {
             title: myname || attrs['friendly_name'],
             natural_speed: attrs['natural_speed'],
@@ -313,11 +308,10 @@ Natural
         return fanbox
     }
 
-    // 设置UI值
+    // Define UI Parameters
     setUI(fanboxa, {title, natural_speed, direct_speed, state,
         child_lock, oscillating, led_brightness, delay_off_countdown, angle
     }) {
-
         fanboxa.querySelector('.var-title').textContent = title
         // Child Lock
         if (child_lock) {
@@ -410,9 +404,9 @@ Natural
             fb.classList.remove('oscillation')
         }
     }
-/*********************************** UI设置 ************************************/
+/*********************************** UI Settings ************************************/
 
-    // 加入日志开关l
+    // Add to logs
     log() {
         // console.log(...arguments)
     }

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -98,6 +98,43 @@ class FanXiaomi extends HTMLElement {
                     });
                 }
             }
+            ui.querySelector('.button-angle').onclick = () => {
+                this.log('Angle Level')
+                if (ui.querySelector('.fanbox').classList.contains('active')) {
+                    let u = ui.querySelector('.var-angle')
+                    let newAngle
+                    if (u.innerHTML == '30') {
+                        newAngle = 60;
+                    } else if (u.innerHTML == '60') {
+                        newAngle = 90
+                    } else if (u.innerHTML == '90') {
+                        newAngle = 120
+                    } else if (u.innerHTML == '120') {
+                        newAngle = 30
+                    } else {
+                        this.log('Error setting fan angle')
+                    }
+                    u.innerHTML = newAngle
+                    hass.callService('fan', 'xiaomi_miio_set_oscillation_angle', {
+                        angle: newAngle
+                    });
+                }
+            }
+
+            ui.querySelector('.button-childlock').onclick = () => {
+                this.log('Child lock')
+                if (ui.querySelector('.fanbox').classList.contains('active')) {
+                    let u = ui.querySelector('.var-childlock')
+                    let newAngle
+                    if (u.innerHTML == 'On') {
+                        hass.callService('fan', 'xiaomi_miio_set_child_lock_off')
+                        u.innerHTML = 'Off'
+                    } else {
+                        hass.callService('fan', 'xiaomi_miio_set_child_lock_on')
+                        u.innerHTML = 'On'
+                    }
+                }
+            }
             ui.querySelector('.var-natural').onclick = () => {
                 //this.log('Natural')
                 if (ui.querySelector('.fanbox').classList.contains('active')) {
@@ -225,9 +262,11 @@ p{margin:0;padding:0}
 .chevron{position:absolute;top:0;height:100%;opacity:0}
 .show{opacity:1}
 .hidden{opacity:0}
-.chevron.left{left:-30px}
-.chevron.right{right:-30px}
+.chevron.left{left:-30px;cursor:pointer}
+.chevron.right{right:-30px;cursor:pointer}
 .chevron span,.chevron span iron-icon{width:30px;height:100%}
+.button-angle,.button-childlock {cursor:pointer}
+
 
 @keyframes blades{0%{transform:translate(0,0) rotate(0)}
 to{transform:translate(0,0) rotate(3600deg)}
@@ -271,11 +310,11 @@ to{transform:perspective(10em) rotateY(40deg)}
 </div>
 </div>
 <div class="attr-row">
-<div class="attr">
+<div class="attr button-childlock">
 <p class="attr-title">Child Lock</p>
 <p class="attr-value var-childlock">0</p>
 </div>
-<div class="attr">
+<div class="attr button-angle">
 <p class="attr-title">Angle(&deg;)</p>
 <p class="attr-value var-angle">120</p>
 </div>

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -21,14 +21,24 @@ class FanXiaomi extends HTMLElement {
 
         const attrs = state.attributes;
 
+        let p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
+        let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
+        let model = attrs['model']
+        let speed_list
+        if (model === 'dmaker.fan.p5') {
+            speed_list = p5_speed_list
+        } else {
+            speed_list = za4_speed_list
+        }
+        
         if (!this.card) {
             const card = document.createElement('ha-card');
             card.className = 'fan-xiaomi'
 
-            // 创建UI
+            // Create UI
             card.appendChild(ui)
 
-            //调整风扇角度事件绑定
+            //Adjust fan angle event binding
             ui.querySelector('.left').onmouseover = () => {
                 ui.querySelector('.left').classList.replace('hidden','show')
             }
@@ -60,7 +70,7 @@ class FanXiaomi extends HTMLElement {
                 }
                 return false;
             }
-            // 定义事件
+            // Define the event
             ui.querySelector('.c1').onclick = () => {
                 this.log('Toggle')
                 hass.callService('fan', 'toggle', {
@@ -75,19 +85,24 @@ class FanXiaomi extends HTMLElement {
                     let icon = u.querySelector('.icon-waper > iron-icon')
                     let newSpeed
                     if (icon.getAttribute('icon') == "mdi:numeric-1-box-outline") {
-                        newSpeed = 40
+                        newSpeed = speed_list['Level 2']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
-                        newSpeed = 60
+                        newSpeed = speed_list['Level 3']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-3-box-outline") {
-                        newSpeed = 80
+                        newSpeed = speed_list['Level 4']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        newSpeed = 100
-                        iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
+                        if (model === 'dmaker.fan.p5') { // For p5 last speed is Level 4
+                            newSpeed = speed_list['Level 1']
+                            iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
+                        } else {
+                            newSpeed = speed_list['Level 5']
+                            iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
+                        }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {
-                        newSpeed = 20
+                        newSpeed = speed_list['Level 1']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                     } else {
                         this.log('Error setting fan speed')
@@ -172,13 +187,13 @@ class FanXiaomi extends HTMLElement {
                 }
             }
             ui.querySelector('.var-title').onclick = () => {
-                this.log('对话框')
+                this.log('Dialog box')
                 card.querySelector('.dialog').style.display = 'block'
             }
             this.card = card;
             this.appendChild(card);
         }
-        //设置值更新UI
+        //Set value update UI
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {
             title: myname || attrs['friendly_name'],
             natural_speed: attrs['natural_speed'],
@@ -188,7 +203,10 @@ class FanXiaomi extends HTMLElement {
             oscillating: attrs['oscillating'],
             led_brightness: attrs['led_brightness'],
             delay_off_countdown: attrs['delay_off_countdown'],
-            angle: attrs['angle']
+            angle: attrs['angle'],
+            speed: attrs['speed'],
+            model: attrs['model'],
+            speed_list: speed_list
         })
     }
 
@@ -205,7 +223,7 @@ class FanXiaomi extends HTMLElement {
         return 1;
     }
 
-    /*********************************** UI设置 ************************************/
+    /*********************************** UI settings ************************************/
     getUI() {
 
         let csss='';
@@ -282,7 +300,7 @@ to{transform:perspective(10em) rotateY(40deg)}
 
 </style>
 <div class="title">
-<p class="var-title">儿童房</p>
+<p class="var-title">Playground</p>
 </div>
 <div class="fanbox">
 <div class="blades ">
@@ -353,9 +371,10 @@ Natural
         return fanbox
     }
 
-    // 设置UI值
+    // Set the UI value
     setUI(fanboxa, {title, natural_speed, direct_speed, state,
-        child_lock, oscillating, led_brightness, delay_off_countdown, angle
+        child_lock, oscillating, led_brightness, delay_off_countdown, angle, 
+        speed, model, speed_list
     }) {
 
         fanboxa.querySelector('.var-title').textContent = title
@@ -416,13 +435,18 @@ Natural
             // iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-0-box-outline"></iron-icon>'
         }
         let direct_speed_int = Number(direct_speed)
-        if (direct_speed_int <= 20) {
+        
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed
+            direct_speed_int = speed_list[speed]
+        }
+        
+        if (direct_speed_int <= speed_list['Level 1']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 40) {
+        } else if (direct_speed_int <= speed_list['Level 2']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 60) {
+        } else if (direct_speed_int <= speed_list['Level 3']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= 80) {
+        } else if (direct_speed_int <= speed_list['Level 4']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
         } else {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
@@ -453,9 +477,9 @@ Natural
             fb.classList.remove('oscillation')
         }
     }
-/*********************************** UI设置 ************************************/
+/*********************************** UI Set up ************************************/
 
-    // 加入日志开关l
+    // Add log switch
     log() {
         // console.log(...arguments)
     }

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -22,10 +22,11 @@ class FanXiaomi extends HTMLElement {
         }
 
         const attrs = state.attributes;
-
-        let p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
-        let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
-        let model = attrs['model']
+        const model = attrs['model']
+        
+        const p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
+        const za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
+        
         let speed_list
         if (model === 'dmaker.fan.p5') {
             speed_list = p5_speed_list
@@ -120,7 +121,7 @@ class FanXiaomi extends HTMLElement {
                     let u = ui.querySelector('.var-angle')
                     let newAngle
                     if (u.innerHTML == '30') {
-                        newAngle = 60;
+                        newAngle = 60
                     } else if (u.innerHTML == '60') {
                         newAngle = 90
                     } else if (u.innerHTML == '90') {
@@ -130,9 +131,57 @@ class FanXiaomi extends HTMLElement {
                     } else {
                         this.log('Error setting fan angle')
                     }
-                    u.innerHTML = newAngle
+                    //u.innerHTML = newAngle
                     hass.callService('fan', 'xiaomi_miio_set_oscillation_angle', {
                         angle: newAngle
+                    });
+                }
+            }
+            
+            ui.querySelector('.button-timer').onclick = () => {
+                this.log('Timer')
+                if (ui.querySelector('.fanbox').classList.contains('active')) {
+                    
+                    let u = ui.querySelector('.var-timer')
+                    
+                    let curTimer
+                    let timeParts = u.textContent.split(/[ ]+/)
+                    //split by space, if two parts - we have hours and minutes
+                    if (timeParts.length > 1) {
+                        curTimer = parseInt(timeParts[0].replace(/\D/g ,'')) * 60
+                            + parseInt(timeParts[1].replace(/\D/g ,''))
+                    }else {
+                        curTimer = parseInt(timeParts[0].replace(/\D/g ,''))
+                    }
+                    
+                    let newTimer
+                    if (curTimer < 60) {
+                        newTimer = 60
+                    } else if (curTimer < 120) {
+                        newTimer = 120
+                    } else if (curTimer < 180) {
+                        newTimer = 180
+                    } else if (curTimer < 240) {
+                        newTimer = 240
+                    } else if (curTimer < 300) {
+                        newTimer = 300
+                    } else if (curTimer < 360) {
+                        newTimer = 360
+                    } else if (curTimer < 420) {
+                        newTimer = 420
+                    } else if (curTimer < 480) {
+                        newTimer = 480
+                    } else {
+                        newTimer = 60
+                    }
+                    
+                    // p5 uses minutes, others use seconds
+                    if (model !== 'dmaker.fan.p5'){
+                        newTime = newTime * 60
+                    }
+                    
+                    hass.callService('fan', 'xiaomi_miio_set_delay_off', {
+                        delay_off_countdown: newTimer
                     });
                 }
             }
@@ -144,10 +193,10 @@ class FanXiaomi extends HTMLElement {
                     let newAngle
                     if (u.innerHTML == 'On') {
                         hass.callService('fan', 'xiaomi_miio_set_child_lock_off')
-                        u.innerHTML = 'Off'
+                        //u.innerHTML = 'Off'
                     } else {
                         hass.callService('fan', 'xiaomi_miio_set_child_lock_on')
-                        u.innerHTML = 'On'
+                        //u.innerHTML = 'On'
                     }
                 }
             }
@@ -286,7 +335,7 @@ p{margin:0;padding:0}
 .chevron.left{left:-30px;cursor:pointer}
 .chevron.right{right:-30px;cursor:pointer}
 .chevron span,.chevron span iron-icon{width:30px;height:100%}
-.button-angle,.button-childlock {cursor:pointer}
+.button-angle,.button-childlock,.button-timer {cursor:pointer}
 
 
 @keyframes blades{0%{transform:translate(0,0) rotate(0)}
@@ -339,7 +388,7 @@ to{transform:perspective(10em) rotateY(40deg)}
 <p class="attr-title">Angle(&deg;)</p>
 <p class="attr-value var-angle">120</p>
 </div>
-<div class="attr">
+<div class="attr button-timer">
 <p class="attr-title">Timer</p>
 <p class="attr-value var-timer">0</p>
 </div>
@@ -393,7 +442,11 @@ Natural
         // Timer
         let timer_display = '0m'
         if(delay_off_countdown) {
-            let total_mins = delay_off_countdown / 60
+            let total_mins = delay_off_countdown
+            if (model !== 'dmaker.fan.p5') {
+                total_mins = total_mins / 60
+            }
+            
             let hours = Math.floor(total_mins / 60)
             let mins = Math.ceil(total_mins % 60)
             if(hours) {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -129,7 +129,8 @@ class FanXiaomi extends HTMLElement {
                     } else if (u.innerHTML == '120') {
                         newAngle = 30
                     } else {
-                        this.log('Error setting fan angle')
+                        newAngle = 30
+                        //this.log('Error setting fan angle')
                     }
                     //u.innerHTML = newAngle
                     hass.callService('fan', 'xiaomi_miio_set_oscillation_angle', {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -89,13 +89,13 @@ class FanXiaomi extends HTMLElement {
                         newSpeed = speed_list[1]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
-                        newSpeed = speed_list['Level 3']
+                        newSpeed = speed_list[2]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-3-box-outline") {
-                        newSpeed = speed_list['Level 4']
+                        newSpeed = speed_list[3]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        if speed_list[5] === undefined {
+                        if (speed_list[5] === undefined) {
                             newSpeed = speed_list[0]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                         } else {
@@ -103,7 +103,7 @@ class FanXiaomi extends HTMLElement {
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
                         }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {
-                        newSpeed = speed_list['Level 1']
+                        newSpeed = speed_list[0]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                     } else {
                         this.log('Error setting fan speed')
@@ -436,8 +436,8 @@ Natural
         }
         let direct_speed_int = Number(direct_speed)
         
-        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
-            direct_speed_int = speed_list[int(speed[-1])-1] //speed contains "Level 1" value
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed            
+            direct_speed_int = speed_list[parseInt(speed[speed.length-1])-1] //speed contains "Level 1" value
             if (mode === 'nature') {
                 natural_speed = true
             } else if (mode === 'normal') {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -437,7 +437,7 @@ Natural
         let direct_speed_int = Number(direct_speed)
         
         if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
-            direct_speed_int = speed_list[speed]
+            direct_speed_int = speed_list[int(speed[-1])-1] //speed contains "Level 1" value
             if (mode === 'nature') {
                 natural_speed = true
             } else if (mode === 'normal') {
@@ -447,11 +447,11 @@ Natural
         
         if (direct_speed_int <= speed_list[0]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 2']) {
+        } else if (direct_speed_int <= speed_list[1]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 3']) {
+        } else if (direct_speed_int <= speed_list[2]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-3-box-outline"></iron-icon>'
-        } else if (direct_speed_int <= speed_list['Level 4']) {
+        } else if (direct_speed_int <= speed_list[3]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
         } else {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -194,7 +194,6 @@ class FanXiaomi extends HTMLElement {
             this.card = card;
             this.appendChild(card);
         }
-        const attrs = state.attributes;
 
         // Set and update UI parameters
         this.setUI(this.card.querySelector('.fan-xiaomi-panel'), {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -23,7 +23,7 @@ class FanXiaomi extends HTMLElement {
 
         const attrs = state.attributes;
 
-        let p5_speed_list = {"Level 1":1,"Level 2":35,"Level 3":70,"Level 4":100}
+        let p5_speed_list = [1, 35, 70, 100]
         let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
         let model = attrs['model']
         let speed_list

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -445,7 +445,7 @@ Natural
             }
         }
         
-        if (direct_speed_int <= speed_list['Level 1']) {
+        if (direct_speed_int <= speed_list[0]) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
         } else if (direct_speed_int <= speed_list['Level 2']) {
             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -24,7 +24,7 @@ class FanXiaomi extends HTMLElement {
         const attrs = state.attributes;
 
         let p5_speed_list = [1, 35, 70, 100]
-        let za4_speed_list = {"Level 1":20,"Level 2":40,"Level 3":60,"Level 4":80, "Level 5":100}
+        let za4_speed_list = [20, 40, 60, 80, 100]
         let model = attrs['model']
         let speed_list
         if (model === 'dmaker.fan.p5') {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -86,7 +86,7 @@ class FanXiaomi extends HTMLElement {
                     let icon = u.querySelector('.icon-waper > iron-icon')
                     let newSpeed
                     if (icon.getAttribute('icon') == "mdi:numeric-1-box-outline") {
-                        newSpeed = speed_list['Level 2']
+                        newSpeed = speed_list[1]
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-2-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-2-box-outline") {
                         newSpeed = speed_list['Level 3']

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -207,6 +207,7 @@ class FanXiaomi extends HTMLElement {
             delay_off_countdown: attrs['delay_off_countdown'],
             angle: attrs['angle'],
             speed: attrs['speed'],
+            mode: attrs['mode'],
             model: attrs['model'],
             speed_list: speed_list
         })
@@ -377,7 +378,7 @@ Natural
   
     setUI(fanboxa, {title, natural_speed, direct_speed, state,
         child_lock, oscillating, led_brightness, delay_off_countdown, angle, 
-        speed, model, speed_list
+        speed, mode, model, speed_list
     }) {
         fanboxa.querySelector('.var-title').textContent = title
         // Child Lock
@@ -435,8 +436,13 @@ Natural
         }
         let direct_speed_int = Number(direct_speed)
         
-        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed
+        if (model === 'dmaker.fan.p5') { //p5 does not report direct_speed and natural_speed
             direct_speed_int = speed_list[speed]
+            if (mode === 'nature') {
+                natural_speed = true
+            } else if (mode === 'normal') {
+                natural_speed = false
+            }
         }
         
         if (direct_speed_int <= speed_list['Level 1']) {

--- a/fan-xiaomi.js
+++ b/fan-xiaomi.js
@@ -95,11 +95,11 @@ class FanXiaomi extends HTMLElement {
                         newSpeed = speed_list['Level 4']
                         iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-4-box-outline"></iron-icon>'
                     } else if (icon.getAttribute('icon') == "mdi:numeric-4-box-outline") {
-                        if (model === 'dmaker.fan.p5') { // For p5 last speed is Level 4
-                            newSpeed = speed_list['Level 1']
+                        if speed_list[5] === undefined {
+                            newSpeed = speed_list[0]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-1-box-outline"></iron-icon>'
                         } else {
-                            newSpeed = speed_list['Level 5']
+                            newSpeed = speed_list[4]
                             iconSpan.innerHTML = '<iron-icon icon="mdi:numeric-5-box-outline"></iron-icon>'
                         }
                     } else if (icon.getAttribute('icon') == "mdi:numeric-5-box-outline") {


### PR DESCRIPTION
Please check that za4 works as before.

p5 model does not report current direct_speed at which it's operating, so need to use Levels 1-4 which miio reports back to us.
Because p5 reporting only 4 levels, need to loop from 4th level back to 1st. That's the reason levels are different from za4 as well.
In order to support p5 and za4 simultaniusly, added speed_list array.
According to my plan, it should work for za4 as before.